### PR TITLE
Rename parameters, polish code a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "idjits"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idjits"
 description = "A simple command-line tool for generating idjits."
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license-file = "LICENSE.md"
 homepage = "https://github.com/ava-cassiopeia/idjits"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
 mod validation;
 
-pub fn construct_idjits(branches: &Vec<String>, prefix: &String) -> Vec<String> {
+pub fn construct_idjits(branches: &[String], prefix: &str) -> Vec<String> {
   let mut output_idjits: Vec<String> = Vec::new();
 
   for branch in branches {
-    let mut output_alias = prefix.clone().to_string();
+    let mut output_alias = prefix.to_string();
     output_alias.push_str(branch);
 
     let mut output_idjit_pipeline_list: Vec<String> = Vec::new();
   
     for c in branch.chars() {
-      let mut idjit_part = prefix.clone();
+      let mut idjit_part = prefix.to_string();
       idjit_part.push(c);
       output_idjit_pipeline_list.push(idjit_part);
     }
@@ -26,7 +26,7 @@ pub fn construct_idjits(branches: &Vec<String>, prefix: &String) -> Vec<String> 
   return output_idjits;
 }
 
-pub fn compute_branches(phrases: &Vec<String>, pneumonics: &Vec<String>) -> Vec<String> {
+pub fn compute_branches(phrases: &[String], pneumonics: &[String]) -> Vec<String> {
   let mut branches: Vec<String> = Vec::new();
   for phrase in phrases {
     let mut phrase_branches: Vec<String> = Vec::new();
@@ -37,7 +37,7 @@ pub fn compute_branches(phrases: &Vec<String>, pneumonics: &Vec<String>) -> Vec<
         .collect();
 
     for optional_part in &optional_parts {
-      let optional_pneumonics: Vec<&str> = optional_part.split('|').collect();
+      let optional_pneumonics: Vec<String> = optional_part.split('|').map(|i| i.to_string()).collect();
       validation::validate_pneumonics(&pneumonics, &optional_pneumonics);
 
       // Fill out the branches
@@ -45,7 +45,7 @@ pub fn compute_branches(phrases: &Vec<String>, pneumonics: &Vec<String>) -> Vec<
       for existing_branch in &phrase_branches {
         for phrase_pneumonic in &optional_pneumonics {
           let mut new_branch = existing_branch.clone();
-          new_branch.push_str(*phrase_pneumonic);
+          new_branch.push_str(phrase_pneumonic);
           new_branches.push(new_branch);
         }
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,36 +26,36 @@ pub fn construct_idjits(branches: &Vec<String>, prefix: &String) -> Vec<String> 
   return output_idjits;
 }
 
-pub fn compute_branches(pneumonics: &Vec<String>, valid_idjits: &Vec<String>) -> Vec<String> {
+pub fn compute_branches(phrases: &Vec<String>, pneumonics: &Vec<String>) -> Vec<String> {
   let mut branches: Vec<String> = Vec::new();
-  for pneumonic in pneumonics {
-    let mut pneumonic_branches: Vec<String> = Vec::new();
-    let optional_parts: Vec<&str> = pneumonic
+  for phrase in phrases {
+    let mut phrase_branches: Vec<String> = Vec::new();
+    let optional_parts: Vec<&str> = phrase
         .split(&['(', ')'])
         .into_iter()
         .filter(|&item| item != "")
         .collect();
 
     for optional_part in &optional_parts {
-      let optional_idjits: Vec<&str> = optional_part.split('|').collect();
-      validation::validate_idjits(&valid_idjits, &optional_idjits);
+      let optional_pneumonics: Vec<&str> = optional_part.split('|').collect();
+      validation::validate_pneumonics(&pneumonics, &optional_pneumonics);
 
       // Fill out the branches
       let mut new_branches: Vec<String> = Vec::new();
-      for existing_branch in &pneumonic_branches {
-        for idjit in &optional_idjits {
+      for existing_branch in &phrase_branches {
+        for phrase_pneumonic in &optional_pneumonics {
           let mut new_branch = existing_branch.clone();
-          new_branch.push_str(*idjit);
+          new_branch.push_str(*phrase_pneumonic);
           new_branches.push(new_branch);
         }
       }
-      pneumonic_branches.extend(new_branches);
-      for idjit in &optional_idjits {
-        pneumonic_branches.push(idjit.to_string());
+      phrase_branches.extend(new_branches);
+      for phrase_pneumonic in &optional_pneumonics {
+        phrase_branches.push(phrase_pneumonic.to_string());
       }
     }
 
-    branches.extend(pneumonic_branches);
+    branches.extend(phrase_branches);
   }
 
   return branches.into_iter().filter(|b| b.len() > 1).collect();
@@ -67,10 +67,10 @@ mod tests {
 
   #[test]
   fn test_compute_branches() {
-    let pneumonics = vec![
+    let phrases = vec![
       "(a|b)(c)(d|e)".to_string(),
     ];
-    let valid_idjits = vec![
+    let pneumonics = vec![
       "a".to_string(),
       "b".to_string(),
       "c".to_string(),
@@ -78,7 +78,7 @@ mod tests {
       "e".to_string(),
     ];
   
-    let result = compute_branches(&pneumonics, &valid_idjits);
+    let result = compute_branches(&phrases, &pneumonics);
 
     assert_eq!(result, vec![
       "ac",
@@ -97,12 +97,12 @@ mod tests {
   }
 
   #[test]
-  fn test_compute_branches_with_multiple_pneumonics() {
-    let pneumonics = vec![
+  fn test_compute_branches_with_multiple_phrases() {
+    let phrases = vec![
       "(a|b)(c)".to_string(),
       "(d|e)(a)".to_string(),
     ];
-    let valid_idjits = vec![
+    let pneumonics = vec![
       "a".to_string(),
       "b".to_string(),
       "c".to_string(),
@@ -110,7 +110,7 @@ mod tests {
       "e".to_string(),
     ];
   
-    let result = compute_branches(&pneumonics, &valid_idjits);
+    let result = compute_branches(&phrases, &pneumonics);
 
     assert_eq!(result, vec![
       "ac",

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,31 +8,31 @@ struct Args {
   #[arg(long)]
   prefix: Option<String>,
 
-  /// All possible valid idjits, separated by a comma.
-  #[arg(short, long, value_delimiter = ',')]
-  idjits: Vec<String>,
+  /// All possible valid pneumonics, separated by commas.
+  #[arg(long, value_delimiter = ',')]
+  pneumonics: Vec<String>,
 
-  /// The pneumonics to use to generate valid idjits. Can be specified multiple
+  /// The phrases to use to generate valid idjits. Can be specified multiple
   /// times. Follows the convention '(a|b)(c|d|e)'.
   #[arg(short, long)]
-  pneumonic: Vec<String>,
+  phrase: Vec<String>,
 }
 
 fn main() {
   let args = Args::parse();
   let prefix = args.prefix.expect("--prefix is required.");
-  let pneumonics = args.pneumonic;
-  let raw_idjits = args.idjits;
+  let pneumonics = args.pneumonics;
+  let phrases = args.phrase;
 
   if pneumonics.len() < 1 {
     panic!("At least one --pneumonic is required.");
   }
 
-  if raw_idjits.len() < 1 {
-    panic!("At least one idjit (--idjits) must be provided.");
+  if phrases.len() < 1 {
+    panic!("At least one phrase (--phrase) must be provided.");
   }
 
-  let branches = idjits::compute_branches(&pneumonics, &raw_idjits);
+  let branches = idjits::compute_branches(&phrases, &pneumonics);
   let idjits = idjits::construct_idjits(&branches, &prefix);
 
   for idjit in idjits {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,6 +1,6 @@
-pub fn validate_pneumonics(pneumonics: &Vec<String>, maybe_pneumonics: &Vec<&str>) {
+pub fn validate_pneumonics(pneumonics: &[String], maybe_pneumonics: &[String]) {
   for maybe_pneumonic in maybe_pneumonics {
-    if !pneumonics.contains(&String::from(*maybe_pneumonic)) {
+    if !pneumonics.contains(maybe_pneumonic) {
       panic!("'{}' is not a valid pneumonic. Options are: {:?}", maybe_pneumonic, pneumonics);
     }
   }
@@ -20,8 +20,8 @@ mod tests {
       "c".to_string(),
     ];
     let possible_pneumonics = vec![
-      "a",
-      "b",
+      "a".to_string(),
+      "b".to_string(),
     ];
   
     // No need to assert - this will panic if validation fails.
@@ -37,9 +37,9 @@ mod tests {
       "c".to_string(),
     ];
     let possible_pneumonics = vec![
-      "a",
-      "b",
-      "d",
+      "a".to_string(),
+      "b".to_string(),
+      "d".to_string(),
     ];
   
     validate_pneumonics(&pneumonics, &possible_pneumonics);

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,7 +1,7 @@
-pub fn validate_idjits(idjits: &Vec<String>, possible_idjits: &Vec<&str>) {
-  for possible_idjit in possible_idjits {
-    if !idjits.contains(&String::from(*possible_idjit)) {
-      panic!("'{}' is not a valid idjit.", possible_idjit);
+pub fn validate_pneumonics(pneumonics: &Vec<String>, maybe_pneumonics: &Vec<&str>) {
+  for maybe_pneumonic in maybe_pneumonics {
+    if !pneumonics.contains(&String::from(*maybe_pneumonic)) {
+      panic!("'{}' is not a valid pneumonic. Options are: {:?}", maybe_pneumonic, pneumonics);
     }
   }
 
@@ -13,35 +13,35 @@ mod tests {
   use super::*;
 
   #[test]
-  fn test_validate_idjits_validates() {
-    let idjits = vec![
+  fn test_validate_pneumonics_validates() {
+    let pneumonics = vec![
       "a".to_string(),
       "b".to_string(),
       "c".to_string(),
     ];
-    let possible_idjits = vec![
+    let possible_pneumonics = vec![
       "a",
       "b",
     ];
   
     // No need to assert - this will panic if validation fails.
-    validate_idjits(&idjits, &possible_idjits);
+    validate_pneumonics(&pneumonics, &possible_pneumonics);
   }
 
   #[test]
-  #[should_panic(expected = "'d' is not a valid idjit.")]
-  fn test_validate_idjits_panics_if_invalid() {
-    let idjits = vec![
+  #[should_panic(expected = "'d' is not a valid pneumonic.")]
+  fn test_validate_pneumonics_panics_if_invalid() {
+    let pneumonics = vec![
       "a".to_string(),
       "b".to_string(),
       "c".to_string(),
     ];
-    let possible_idjits = vec![
+    let possible_pneumonics = vec![
       "a",
       "b",
       "d",
     ];
   
-    validate_idjits(&idjits, &possible_idjits);
+    validate_pneumonics(&pneumonics, &possible_pneumonics);
   }
 }


### PR DESCRIPTION
This change renames some parameters to match a convention used by an older iteration of idjits.

It also updates some of the implementation to pass around read-only lists of strings instead of vectors, per a suggestion from a friend (still learning Rust).